### PR TITLE
Several tweaks (merge or cherry-pick as you wish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "author": "alkawryk",
   "license": "MIT",
   "dependencies": {
-    "request" : "2.34.0"
+    "request" : "2.67.0"
   }
 }

--- a/tinder.js
+++ b/tinder.js
@@ -203,10 +203,10 @@ function TinderClient(config) {
    * Gets a list of new updates. This will be things like new messages, people who liked you, etc. 
    * @param {Function} callback the callback to invoke when the request completes
    */
-  this.getUpdates = function(callback) {
+  this.getUpdates = function(lastActivity, callback) {
     tinderPost('updates',
       {
-        last_activity_date: lastActivity.toISOString() 
+        last_activity_date: lastActivity
       },
       makeTinderCallback(function(err, data){
         lastActivity = new Date(data.last_activity_date);

--- a/tinder.js
+++ b/tinder.js
@@ -1,5 +1,9 @@
-var TINDER_HOST = "https://api.gotinder.com";
 var request = require('request');
+
+var defaultConfig = {
+    apiHost: "https://api.gotinder.com",
+    apiPath: "",
+};
 
 /**
  * Constructs a new instance of the TinderClient class
@@ -7,11 +11,14 @@ var request = require('request');
  * @constructor
  * @this {TinderClient}
  */
-function TinderClient() {
+function TinderClient(config) {
   var xAuthToken = null;
   var lastActivity = new Date();
   var _this = this;
-  
+
+  // TODO: Add polyfill as dependency?
+  var cfg = Object.assign({}, defaultConfig, config);
+
   /**
    * The current profile's user id
    */
@@ -24,7 +31,7 @@ function TinderClient() {
    */
   var getRequestOptions = function(path, data) {
     var options = {
-      url: TINDER_HOST + "/" + path,
+      url: cfg.apiHost + cfg.apiPath + "/" + path,
       json: data
     };
     


### PR DESCRIPTION
This PR contains three minor improvements.
- Upgrade the `request` library to 2.67, which supports browser usage by wrapping `XmlHttpRequest`. This makes it possible to write client-side tools for the Tinder API.
- Make API host configurable in the `TinderClient` constructor. This makes it possible to direct the client to some other endpoint, e.g. an API proxy. This is useful alongside the browser support (above) to avoid CORS restrictions.
- Make `lastActivity` a parameter of `getUpdates()`, so that a library user isn't limited to using the internal update timestamp.

I've made these changes to be able to create a technical proof of concept of [a more capable match manager interface](https://github.com/richardolsson/tinder-match-manager), in case you want to see them in action.
